### PR TITLE
Glossary Page

### DIFF
--- a/docs/Help/Glossary
+++ b/docs/Help/Glossary
@@ -1,0 +1,166 @@
+Drehmal commonly renames Minecraft items to make them better adhere to the lore. Here is a list of item names, in their usual Minecraft name and their Drehmal counterpart. 
+
+## Blocks
+| Vanilla Minecraft | Drehmal |
+| :------------------- | :----------- |
+| Bedrock | Condensed Veilstone |
+| Deepslate Gold Ore, Nether Gold Ore | Slate Gold Ore |
+| Deepslate Iron Ore | Slate Iron Ore |
+| Nether Brick Slab | Taihryte Brick Slab |
+| Soul Torch | Orderflame Torch |
+| Soul Wall Torch | Orderflame Wall Torch |
+| Respawn Anchor | Spectra Charge |
+| Deepslate Diamond Ore | Slate Diamond Ore |
+| Blue Ice | Divine Ice |
+| Nether Portal | OFF LIMITS |
+| Deepslate Lapis Lazuli Ore | Slate Lapis Lazuli Ore |
+| Nether Bricks | Taihryte Bricks |
+| Nether Brick Fence | Taihryte Brick Fence |
+| Nether Brick Stairs | Taihryte Brick Stairs | 
+| Warped Stem Block | Aventurine Pileus Block |
+| Warped Stem | Aventurine Stem |
+| Stripped Warped Stem | Stripped Aventurine Stem |
+| Warped Hyphae | Aventurine Hyphae |
+| Stripped Warped Hyphae | Stripped Aventurine Hyphae |
+| Crimson Stem | Carnelian Stem |
+| Stripped Crimson Stem | Stripped Carnelian Stem |
+| Warped Nylium | Aventurine Nylium |
+| Crimson Nylium | Carnelian Nylium |
+| Warped Fungus | Aventurine Fungus |
+| Crimson Fungus | Carnelian Fungus |
+| Warped Roots | Aventurine Roots |
+| Crimson Roots | Carnelian Roots |
+| Nether Sprouts | Aventurine Sprouts |
+| Shroomlight | Flarepod |
+| Soul Soil | Souldust |
+| Warped Planks | Aventurine Planks |
+| Warped Slab | Aventurine Slab |
+| Warped Pressure Plate | Aventurine Pressure Plate |
+| Warped Fence | Aventurine Fence |
+| Warped Trapdoor | Aventurine Trapdoor |
+| Warped Fence Gate | Aventurine Fence Gate |
+| Warped Stairs | Aventurine Stairs |
+| Warped Button | Aventurine Button |
+| Warped Door | Aventurine Door |
+| Warped Sign | Aventurine Sign |
+| Warped Hanging Sign | Aventurine Hanging Sign |
+| Warped Wall Sign | Aventurine Wall Sign |
+| Crimson Planks | Carnelian Planks |
+| Crimson Slab | Carnelian Slab |
+| Crimson Pressure Plate | Carnelian Pressure Plate |
+| Crimson Fence | Carnelian Fence |
+| Crimson Trapdoor | Carnelian Trapdoor |
+| Crimson Fence Gate  | Carnelian Fence Gate |
+| Crimson Stairs | Carnelian Stairs |
+| Crimson Button | Carnelian Button |
+| Crimson Door | Carnelian Door |
+| Crimson Sign | Carnelian Sign |
+| Crimson Wall Sign | Carnelian Wall Sign |
+| Crimson Hanging Sign | Carnelian Hanging Sign |
+| Soulfire | Orderflame |
+| Enchanting Table | Runic Inscription Table |
+| Endstone | Otherstone |
+| Endstone Bricks | Otherstone Bricks |
+| End Portal Frame | Anomaly Inhibitor |
+| Dragon Egg | Fear's Husk |
+| Emerald Ore | Serpent Scale Ore |
+| Deepslate Emerald Ore | Slate Serpent Scale Ore |
+| Emerald Block | Block of Serpent Scales |
+| Beacon | Asterial Array |
+| Nether Quartz Ore | Slate Quartz Ore |
+| Sea Lantern | Azure Lantern |
+| End Rod | Light Rod |
+| Purpur Block | Amethyst Tile Block |
+| Purpur Pillar | Infused Amethyst |
+| Purpur Stairs | Amethyst Tile Stairs |
+| Purpur Slab | Amethyst Tile Slab |
+| Nether Wart Block | Crucible Wart Block |
+| Red Nether Bricks | Red Taihryte Bricks |
+| Shulker Box | Runic Vessel |
+| End Portal | Anomaly |
+| Wither Rose | Cthonic Rose |
+| Wither Skeleton Skull | Chthonic Skeleton Skull |
+| Dragon Head | Head of Tethlaen |
+| End Gateway | Void Gateway |
+| Structure Block | Minecraft Sex Block |
+| Bubble Column | bubbles!! |
+| Conduit | Aqua Fortis |
+| Jigsaw Block | Jiggy Block |
+| End Stone Brick Stairs | Otherstone Brick Stairs |
+| Red Nether Brick Stairs | Red Taihryte Brick Stairs |
+| End Stone Brick Slab | Otherstone Brick Slab |
+| Nether Brick Wall | Taihryte Brick Wall |
+| Red Nether Brick Wall | Taihryte Brick Wall |
+| End Stone Brick Wall | Otherstone Brick Wall |
+| Soul Lantern | Orderflame Lantern |
+| Soul Campfire | Orderflame Campfire |
+| Netherite Block | Block of Celestial Alloy |
+| Ancient Debris | Celestial Debris |
+| Crying Obsidian | Silent Obsidian |
+| Cracked Nether Bricks | Cracked Taihryte Bricks |
+| Chiseled Nether Bricks | Chiseled Taihryte Bricks| 
+| Deepslate Copper Ore | Slate Copper Ore |
+| Deepslate | Slate |
+| Ender Chest | Primal Cache |
+
+## Items
+| Vanilla Minecraft | Drehmal |
+| :------------------- | :----------- |
+| Spectral Arrow | Truesight Arrow |
+| Emerald | Scale |
+| Enchanted Golden Apple | Fruit of the Primal Tree |
+| Ender Pearl | Primal Pearl |
+| Nether Wart | Crucible Wart |
+| Ghast Tear | Quicksilver Tear |
+| End Crystal | Unstable Primal Catalyst |
+| Ender Eye | Oculus of Nothing |
+| Experience Bottle | Arcane Bottle |
+| Nether Star | Soul Asteria |
+| Enchanted Book | Runic Book | 
+| Nether Brick | Taihryte Brick |
+| Prismarine Crystals | Azure Crystals |
+| Elytra | Glider |
+| Shulker Shell | Null Shell |
+| Phantom Membrane | Ruin Membrane |
+| Heart of the Sea | Moonstone |
+| Netherite Scrap | Celestial Chondrule |
+| Netherite Ingot | Celestial Alloy |
+| Netherite Helmet | Celestial Helmet |
+| Netherite Chestplate | Celestial Chestplate |
+| Netherite Leggings | Celestial Leggings |
+| Netherite Boots | Celestial Boots |
+| Netherite Axe | Celestial Axe |
+| Netherite Pickaxe | Celestial Pickaxe |
+| Netherite Hoe | Celestial Hoe |
+| Netherite Shovel | Celestial Shovel |
+| Netherite Sword | Celestial Sword |
+| Warped Fungus on a Stick | Aventurine Fungus on a Stick |
+
+## Mobs
+| Vanilla Minecraft | Drehmal |
+| :------------------- | :----------- |
+| Cave Spider | Arahk |
+| Elder Guardian | Dahrkin Negator |
+| Ender Dragon | Tethlaen, Lost to Nothing |
+| Enderman | Primal Walker|
+| Endermite | Nullpest
+| Evoker | Mihkmari Arcanist |
+| Ghast | Charbelcher |
+| Guardian | Dahrkin |
+| Ravager | Grafted Mikhmari |
+| Killer Bunny | Heartbreaker Bunny |
+| Phantom | Skullchild |
+| Piglin | Maelmari |
+| Piglin Brute | Maelmari Brute |
+| Pillager | Mikhmari |
+| Polar Bear | Faehrbear | 
+| Shulker | Null Clam |
+| Strider | Laikin |
+| Iron Golem | Runic Golem |
+| Vindicator | Mikhmari Warrior |
+| Witch | Forsaken Alchemist |
+| Wither | Soulgrafted |
+| Wither Skeleton | Chthonic Skeleton |
+| Zoglin | Zwinebreed |
+| Zombified Piglin | Necrotic Maelmari |
+


### PR DESCRIPTION
Adds a Glossary page in the Help Folder that lists Minecraft blocks, items, and mob names changed by the Drehmal resource pack.